### PR TITLE
Fix for find user which start with numeric character

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,8 +177,7 @@ class User < ActiveRecord::Base
 
   class << self
     def find_by_id_or_username(param)
-      case
-      when param.to_i > 0
+      if /\A[0-9]+\z/ =~ param.to_s
         User.find(param)
       else
         User.find_by(username: param)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -130,5 +130,23 @@ describe User do
         user.moderator?.should be_false
       end
     end
+
+    describe ".find_by_id_or_username" do
+      context "only numeric character" do
+        let!(:user) { User.make! }
+
+        it "finds user by id" do
+          User.find_by_id_or_username(user.id).should eq user
+        end
+      end
+
+      context "username which start with numeric character" do
+        let!(:user) { User.make!(username: "0ab") }
+
+        it "finds user by username" do
+          User.find_by_id_or_username("0ab").should eq user
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello.
Thank you for the service! I am looking forward to future. 

When called `User.find_by_id_or_username` with start with numeric character, It seems that it searches by user id. 

Example...

access this url: http://www.photographer.io/en/u/03w (my friend)
expect: http://www.photographer.io/en/u/1306
actual: http://www.photographer.io/en/u/3

What do you think?

Sorry about my poor English :)
