### PR TITLE
Scores decrement automatically after 2 days

### DIFF
--- a/app/models/photograph.rb
+++ b/app/models/photograph.rb
@@ -267,9 +267,9 @@ class Photograph < ActiveRecord::Base
   end
 
   def increment_score(by = 1)
-    Photograph.rankings.increment(id, by) do
-      set_highest_rank
-    end
+    Photograph.rankings.increment(id, by)
+    set_highest_rank
+    Worker.perform_in(2.days, 'Photograph', id, :decrement_score, by)
   end
 
   def decrement_score(by = 1)

--- a/app/workers/photograph_worker.rb
+++ b/app/workers/photograph_worker.rb
@@ -1,0 +1,8 @@
+class PhotographWorker
+  include Sidekiq::Worker
+
+  def perform(photograph_id, method, *args)
+    photo = Photograph.find(photograph_id)
+    photo.send(method, *args)
+  end
+end

--- a/app/workers/worker.rb
+++ b/app/workers/worker.rb
@@ -1,0 +1,8 @@
+class Worker
+  include Sidekiq::Worker
+
+  def perform(klass, id, method, *args)
+    model = klass.constantize.find(id)
+    model.send(method, *args)
+  end
+end

--- a/spec/models/favourite_spec.rb
+++ b/spec/models/favourite_spec.rb
@@ -7,6 +7,8 @@ describe Favourite do
   let(:user) { favourite.user }
   let(:counter) { double("counter", increment: true, decrement: true) }
 
+  before { Photograph.any_instance.stub(:set_highest_rank) { true } }
+
   it { should belong_to(:user) }
   it { should belong_to(:photograph) }
   it { should have_many(:notifications) }

--- a/spec/models/photograph_spec.rb
+++ b/spec/models/photograph_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Photograph do
   let(:user) { User.make! }
-  let(:photograph) { Photograph.make(user: user) }
+  let(:photograph) { Photograph.make!(user: user) }
   subject { photograph }
 
   describe "associations" do
@@ -100,6 +100,16 @@ describe Photograph do
 
       it "is incrementable" do
         photograph.views.increment.should be_true
+      end
+    end
+  end
+
+  describe "score" do
+    describe "#increment_score" do
+      it "enqueues a score decrement" do
+        expect {
+          photograph.increment_score(1)
+        }.to change(Worker.jobs, :size).by(1)
       end
     end
   end

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,0 +1,1 @@
+require 'sidekiq/testing'

--- a/spec/workers/worker_spec.rb
+++ b/spec/workers/worker_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Worker do
+  subject { Worker.new }
+  let(:photograph) { Photograph.make }
+  before { Photograph.stub(:find) { photograph } }
+  before { Photograph.stub(:increment_score) { true } }
+
+  it "runs any method" do
+    photograph.should_receive(:increment_score)
+    subject.perform('Photograph', 1, :increment_score, 1)
+  end
+end


### PR DESCRIPTION
Automatically reduce the score 2 days after it's incremented. This should 
improve the speed at which the Recommended section changes.
