### PR TITLE
Fix an ERROR in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'kaminari'
 gem 'redcarpet'
 
 # models
-gem 'friendly_id', github: 'FriendlyId/friendly_id', branch: 'rails4'
+gem 'friendly_id', github: 'FriendlyId/friendly_id', branch: 'master'
 gem 'closure_tree', github: 'mceachen/closure_tree', branch: 'wip_rails4'
 
 # assets


### PR DESCRIPTION
FriendlyID has already removed the branch 'rails4', and now the branch 'master' is working under rails4.
